### PR TITLE
Fixed typographical error, changed accidentaly to accidentally in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ any user's timeline using API, so if you've produced, say 3500 tweets in your ti
 (inluding retweets and replies), the first 300 would be gone somewhere in distant 
 Twitterverse forever.
 
-I have accidentaly found about this via `Zach Holman's blog article`_ the other day
+I have accidentally found about this via `Zach Holman's blog article`_ the other day
 and thought writing a simple fetcher script to dump tweets into an offline text file 
 would be nice Python excercise for a PHP'er keen to learn more Python.
 


### PR DESCRIPTION
@adlorenz, I've corrected a typographical error in the documentation of the [twitbak](https://github.com/adlorenz/twitbak) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
